### PR TITLE
Restrict server admin alliance management

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,7 @@ I love this community and thank you all for being part of this journey. ❤️
 - This feature adds admin to your bot. 
 - After pressing it, it asks you to tag the admin
     - The administrators you add cannot access all settings.
-    - They can only see and manage alliances in the discord they are in.
-    - They can also see specially authorized alliances
+    - Server admins can manage only the alliances assigned to them.
 
 ### ➖ Remove Admin
 
@@ -249,7 +248,7 @@ I love this community and thank you all for being part of this journey. ❤️
 ### 🔗 Assign Alliance to Admin
 
 - Allows you to assign a custom alliance management to the admins you add
-- This is done in different discord server so that the admins you want can see the other alliances
+- You can assign alliances from any server to the admins you add
 
 ### ➖ Delete Admin Permissions
 

--- a/cogs/alliance_member_operations.py
+++ b/cogs/alliance_member_operations.py
@@ -184,7 +184,7 @@ class AllianceMemberOperations(commands.Cog):
 
                     special_alliance_text = ""
                     if special_alliances:
-                        special_alliance_text = "\n\n**Special Access Alliances**\n"
+                        special_alliance_text = "\n\n**Assigned Alliances**\n"
                         special_alliance_text += "━━━━━━━━━━━━━━━━━━━━━━\n"
                         for _, name in special_alliances:
                             special_alliance_text += f"🔸 {name}\n"
@@ -197,7 +197,7 @@ class AllianceMemberOperations(commands.Cog):
                             "**Permission Details**\n"
                             "━━━━━━━━━━━━━━━━━━━━━━\n"
                             f"👤 **Access Level:** `{'Global Admin' if is_initial == 1 else 'Server Admin'}`\n"
-                            f"🔍 **Access Type:** `{'All Alliances' if is_initial == 1 else 'Server + Special Access'}`\n"
+                            f"🔍 **Access Type:** `{'All Alliances' if is_initial == 1 else 'Assigned Alliances'}`\n"
                             f"📊 **Available Alliances:** `{len(alliances)}`\n"
                             "━━━━━━━━━━━━━━━━━━━━━━"
                             f"{special_alliance_text}"
@@ -270,7 +270,7 @@ class AllianceMemberOperations(commands.Cog):
 
                     special_alliance_text = ""
                     if special_alliances:
-                        special_alliance_text = "\n\n**Special Access Alliances**\n"
+                        special_alliance_text = "\n\n**Assigned Alliances**\n"
                         special_alliance_text += "━━━━━━━━━━━━━━━━━━━━━━\n"
                         for _, name in special_alliances:
                             special_alliance_text += f"🔸 {name}\n"
@@ -283,7 +283,7 @@ class AllianceMemberOperations(commands.Cog):
                             "**Permission Details**\n"
                             "━━━━━━━━━━━━━━━━━━━━━━\n"
                             f"👤 **Access Level:** `{'Global Admin' if is_initial == 1 else 'Server Admin'}`\n"
-                            f"🔍 **Access Type:** `{'All Alliances' if is_initial == 1 else 'Server + Special Access'}`\n"
+                            f"🔍 **Access Type:** `{'All Alliances' if is_initial == 1 else 'Assigned Alliances'}`\n"
                             f"📊 **Available Alliances:** `{len(alliances)}`\n"
                             "━━━━━━━━━━━━━━━━━━━━━━"
                             f"{special_alliance_text}"
@@ -556,7 +556,7 @@ class AllianceMemberOperations(commands.Cog):
 
                     special_alliance_text = ""
                     if special_alliances:
-                        special_alliance_text = "\n\n**Special Access Alliances**\n"
+                        special_alliance_text = "\n\n**Assigned Alliances**\n"
                         special_alliance_text += "━━━━━━━━━━━━━━━━━━━━━━\n"
                         for _, name in special_alliances:
                             special_alliance_text += f"🔸 {name}\n"
@@ -569,7 +569,7 @@ class AllianceMemberOperations(commands.Cog):
                             "**Permission Details**\n"
                             "━━━━━━━━━━━━━━━━━━━━━━\n"
                             f"👤 **Access Level:** `{'Global Admin' if is_initial == 1 else 'Server Admin'}`\n"
-                            f"🔍 **Access Type:** `{'All Alliances' if is_initial == 1 else 'Server + Special Access'}`\n"
+                            f"🔍 **Access Type:** `{'All Alliances' if is_initial == 1 else 'Assigned Alliances'}`\n"
                             f"📊 **Available Alliances:** `{len(alliances)}`\n"
                             "━━━━━━━━━━━━━━━━━━━━━━"
                             f"{special_alliance_text}"
@@ -725,7 +725,7 @@ class AllianceMemberOperations(commands.Cog):
                     
                     special_alliance_text = ""
                     if special_alliances:
-                        special_alliance_text = "\n\n**Special Access Alliances**\n"
+                        special_alliance_text = "\n\n**Assigned Alliances**\n"
                         special_alliance_text += "━━━━━━━━━━━━━━━━━━━━━━\n"
                         for _, name in special_alliances:
                             special_alliance_text += f"🔸 {name}\n"
@@ -739,7 +739,7 @@ class AllianceMemberOperations(commands.Cog):
                             "**Permission Details**\n"
                             "━━━━━━━━━━━━━━━━━━━━━━\n"
                             f"👤 **Access Level:** `{'Global Admin' if is_initial == 1 else 'Server Admin'}`\n"
-                            f"🔍 **Access Type:** `{'All Alliances' if is_initial == 1 else 'Server + Special Access'}`\n"
+                            f"🔍 **Access Type:** `{'All Alliances' if is_initial == 1 else 'Assigned Alliances'}`\n"
                             f"📊 **Available Alliances:** `{len(alliances)}`\n"
                             "━━━━━━━━━━━━━━━━━━━━━━"
                             f"{special_alliance_text}"
@@ -1082,6 +1082,12 @@ class AllianceMemberOperations(commands.Cog):
             await interaction.response.send_message("You do not have permission to use this command.", ephemeral=True)
             return
 
+        alliances, _, is_global = await self.get_admin_alliances(interaction.user.id, interaction.guild_id)
+        allowed_ids = [str(aid) for aid, _ in alliances]
+        if not is_global and str(alliance_id) not in allowed_ids:
+            await interaction.response.send_message("You do not have permission to manage this alliance.", ephemeral=True)
+            return
+
         ids_list = [fid.strip() for fid in ids.split(",")]
 
         
@@ -1366,72 +1372,53 @@ class AllianceMemberOperations(commands.Cog):
 
     async def get_admin_alliances(self, user_id: int, guild_id: int):
         try:
-            
+
             with sqlite3.connect('db/settings.sqlite') as settings_db:
                 cursor = settings_db.cursor()
                 cursor.execute("SELECT is_initial FROM admin WHERE id = ?", (user_id,))
                 admin_result = cursor.fetchone()
-                
+
                 if not admin_result:
                     self.log_message(f"User {user_id} is not an admin")
                     return [], [], False
-                    
+
                 is_initial = admin_result[0]
-                
+
             if is_initial == 1:
-                
+
                 with sqlite3.connect('db/alliance.sqlite') as alliance_db:
                     cursor = alliance_db.cursor()
                     cursor.execute("SELECT alliance_id, name FROM alliance_list ORDER BY name")
                     alliances = cursor.fetchall()
                     return alliances, [], True
-            
-            
-            server_alliances = []
-            special_alliances = []
-            
-            
-            with sqlite3.connect('db/alliance.sqlite') as alliance_db:
-                cursor = alliance_db.cursor()
-                cursor.execute("""
-                    SELECT DISTINCT alliance_id, name 
-                    FROM alliance_list 
-                    WHERE discord_server_id = ?
-                    ORDER BY name
-                """, (guild_id,))
-                server_alliances = cursor.fetchall()
-            
-            
+
             with sqlite3.connect('db/settings.sqlite') as settings_db:
                 cursor = settings_db.cursor()
                 cursor.execute("""
-                    SELECT alliances_id 
-                    FROM adminserver 
+                    SELECT alliances_id
+                    FROM adminserver
                     WHERE admin = ?
                 """, (user_id,))
-                special_alliance_ids = cursor.fetchall()
-                
-            
-            if special_alliance_ids:
-                with sqlite3.connect('db/alliance.sqlite') as alliance_db:
-                    cursor = alliance_db.cursor()
-                    placeholders = ','.join('?' * len(special_alliance_ids))
-                    cursor.execute(f"""
-                        SELECT DISTINCT alliance_id, name
-                        FROM alliance_list
-                        WHERE alliance_id IN ({placeholders})
-                        ORDER BY name
-                    """, [aid[0] for aid in special_alliance_ids])
-                    special_alliances = cursor.fetchall()
-            
-            all_alliances = list({(aid, name) for aid, name in (server_alliances + special_alliances)})
-            
-            if not all_alliances and not special_alliances:
+                alliance_ids = [row[0] for row in cursor.fetchall()]
+
+            if not alliance_ids:
                 return [], [], False
-            
-            return all_alliances, special_alliances, False
-                
+
+            with sqlite3.connect('db/alliance.sqlite') as alliance_db:
+                cursor = alliance_db.cursor()
+                placeholders = ','.join('?' * len(alliance_ids))
+                cursor.execute(f"""
+                    SELECT alliance_id, name
+                    FROM alliance_list
+                    WHERE alliance_id IN ({placeholders})
+                    ORDER BY name
+                """, alliance_ids)
+                alliances = cursor.fetchall()
+
+            return alliances, [], False
+
         except Exception as e:
+            self.log_message(f"Error in get_admin_alliances: {e}")
             return [], [], False
 
     async def handle_button_interaction(self, interaction: discord.Interaction):

--- a/cogs/bot_operations.py
+++ b/cogs/bot_operations.py
@@ -518,7 +518,7 @@ class BotOperations(commands.Cog):
                                         f"👤 **Name:** `{admin_name}`\n"
                                         f"🆔 **Discord ID:** `{selected_admin_id}`\n"
                                         f"👤 **Access Level:** `{'Global Admin' if admin_info[1] == 1 else 'Server Admin'}`\n"
-                                        f"🔍 **Access Type:** `{'All Alliances' if admin_info[1] == 1 else 'Server + Special Access'}`\n"
+                                        f"🔍 **Access Type:** `{'All Alliances' if admin_info[1] == 1 else 'Assigned Alliances'}`\n"
                                         f"📊 **Available Alliances:** `{len(alliance_names)}`\n"
                                         "━━━━━━━━━━━━━━━━━━━━━━\n"
                                     ),
@@ -903,7 +903,7 @@ class BotOperations(commands.Cog):
                             f"👤 **Name:** {admin_name}\n"
                             f"🆔 **ID:** {admin_id}\n"
                             f"👑 **Role:** {'Global Admin' if is_initial == 1 else 'Server Admin'}\n"
-                            f"🔍 **Access Type:** {'All Alliances' if is_initial == 1 else 'Server + Special Access'}\n"
+                            f"🔍 **Access Type:** {'All Alliances' if is_initial == 1 else 'Assigned Alliances'}\n"
                         )
 
                         if alliance_names:

--- a/tests/test_admin_permissions.py
+++ b/tests/test_admin_permissions.py
@@ -1,0 +1,74 @@
+import os
+import sqlite3
+import asyncio
+import unittest
+
+from cogs.alliance_member_operations import AllianceMemberOperations
+
+class DummyUser:
+    def __init__(self, user_id, name="Admin"):
+        self.id = user_id
+        self.name = name
+
+class DummyResponse:
+    def __init__(self):
+        self.messages = []
+    async def send_message(self, content=None, **kwargs):
+        self.messages.append(content)
+
+class DummyInteraction:
+    def __init__(self, user_id, guild_id=1):
+        self.user = DummyUser(user_id)
+        self.guild_id = guild_id
+        self.response = DummyResponse()
+
+class PermissionTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        os.makedirs('db', exist_ok=True)
+        # settings db
+        with sqlite3.connect('db/settings.sqlite') as conn:
+            c = conn.cursor()
+            c.execute("CREATE TABLE IF NOT EXISTS admin (id INTEGER PRIMARY KEY, is_initial INTEGER)")
+            c.execute("CREATE TABLE IF NOT EXISTS adminserver (admin INTEGER, alliances_id INTEGER)")
+            conn.commit()
+        # alliance db
+        with sqlite3.connect('db/alliance.sqlite') as conn:
+            c = conn.cursor()
+            c.execute("CREATE TABLE IF NOT EXISTS alliance_list (alliance_id INTEGER PRIMARY KEY, name TEXT)")
+            conn.commit()
+        # users db required by cog
+        with sqlite3.connect('db/users.sqlite') as conn:
+            c = conn.cursor()
+            c.execute("CREATE TABLE IF NOT EXISTS users (fid INTEGER PRIMARY KEY, nickname TEXT, furnace_lv INTEGER, kid INTEGER, stove_lv_content TEXT, alliance TEXT)")
+            conn.commit()
+        os.makedirs('log', exist_ok=True)
+        self.cog = AllianceMemberOperations(bot=None)
+
+    def tearDown(self):
+        self.cog.conn_alliance.close()
+        self.cog.conn_users.close()
+        for fname in ['db/settings.sqlite','db/alliance.sqlite','db/users.sqlite']:
+            if os.path.exists(fname):
+                os.remove(fname)
+        if os.path.exists('db'):
+            os.rmdir('db')
+        if os.path.exists('log'):
+            os.rmdir('log')
+
+    async def test_add_user_blocked_for_unassigned_alliance(self):
+        # create admin and alliances
+        with sqlite3.connect('db/settings.sqlite') as conn:
+            conn.execute("INSERT INTO admin (id, is_initial) VALUES (1, 0)")
+            conn.execute("INSERT INTO adminserver (admin, alliances_id) VALUES (1, 1)")
+            conn.commit()
+        with sqlite3.connect('db/alliance.sqlite') as conn:
+            conn.execute("INSERT INTO alliance_list (alliance_id, name) VALUES (1,'Alpha')")
+            conn.execute("INSERT INTO alliance_list (alliance_id, name) VALUES (2,'Beta')")
+            conn.commit()
+
+        interaction = DummyInteraction(1, guild_id=1)
+        await self.cog.add_user(interaction, '2', '12345')
+        self.assertTrue(any('permission' in m.lower() for m in interaction.response.messages))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- limit `get_admin_alliances` to only alliances assigned to the admin
- enforce alliance checks in `add_user`
- update UI prompts for new permission model
- clarify admin permissions in README
- add a small unit test covering the new restriction

## Testing
- `python -m unittest discover -s tests -p 'test_*.py' -v`

